### PR TITLE
Set user and group when copying run.bash file

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,5 +37,5 @@ RUN cd gz-test; mkdir build;
 WORKDIR /home/$USERNAME/gz-test/build
 RUN cmake ../ -DBUILD_TESTING=false; sudo make install
 
-COPY run.bash ./
+COPY --chown=$USERNAME:$USERNAME run.bash ./
 ENTRYPOINT ["./run.bash"]


### PR DESCRIPTION
When running gz-test on a Kubernetes pod, we get the following error:
```
Error: failed to start container "simulation": Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "./run.bash": permission denied: unknown
```

The same error is triggered when running this on Docker:

```
docker: Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "./run.bash": permission denied: unknown.
```


This PR attempts to fix this issue by adding `chown` when copying `run.bash`.

**THIS PR HAS NOT BEEN TESTED**

This can be tested after building the new image (`ignitionrobotics/ign-test:0.1-dev`) and running the following command: 

```
docker run -it --name=gz-test --mount type=bind,source="$(pwd)",target=/tmp ignitionrobotics/ign-test:0.1-dev bash
```